### PR TITLE
Fix trailer playback lifecycle and preserve detail background

### DIFF
--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/DetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/DetailActivity.java
@@ -12,17 +12,28 @@ import com.halil.ozel.movieparadise.ui.base.GlideBackgroundManager;
 
 public class DetailActivity extends BaseTVActivity {
 
-    GlideBackgroundManager glideBackgroundManager;
+    private GlideBackgroundManager glideBackgroundManager;
+    private Movie movie;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        Movie movie = getIntent().getExtras().getParcelable(Movie.class.getSimpleName());
+        movie = getIntent().getExtras().getParcelable(Movie.class.getSimpleName());
         DetailFragment detailsFragment = DetailFragment.newInstance(movie);
         addFragment(detailsFragment);
 
         glideBackgroundManager = new GlideBackgroundManager(this);
+        updateBackground();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        updateBackground();
+    }
+
+    private void updateBackground() {
         if (movie != null && movie.getBackdropPath() != null) {
             glideBackgroundManager.loadImage(HttpClientModule.BACKDROP_URL + movie.getBackdropPath());
         } else {

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/player/PlayerActivity.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/player/PlayerActivity.java
@@ -19,4 +19,20 @@ public class PlayerActivity extends Activity {
         Intent intent = getIntent();
         youtubeTvView.playVideo(intent.getStringExtra("videoId"));
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (youtubeTvView != null) {
+            youtubeTvView.onResume();
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        if (youtubeTvView != null) {
+            youtubeTvView.onPause();
+        }
+        super.onPause();
+    }
 }


### PR DESCRIPTION
## Summary
- maintain detail background after returning from trailer
- handle YoutubeTvView lifecycle in `PlayerActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685794104b3c832b83db021e6673dbca