### PR TITLE
Add person detail view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.detail.DetailActivity" />
+        <activity android:name=".ui.detail.PersonDetailActivity" />
     </application>
 
     <uses-feature

--- a/app/src/main/java/com/halil/ozel/movieparadise/dagger/components/ApplicationComponent.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/dagger/components/ApplicationComponent.java
@@ -6,6 +6,7 @@ import com.halil.ozel.movieparadise.dagger.AppScope;
 import com.halil.ozel.movieparadise.dagger.modules.ApplicationModule;
 import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
 import com.halil.ozel.movieparadise.ui.detail.DetailFragment;
+import com.halil.ozel.movieparadise.ui.detail.PersonDetailFragment;
 import com.halil.ozel.movieparadise.ui.main.MainFragment;
 import com.halil.ozel.movieparadise.ui.search.SearchFragment;
 
@@ -28,4 +29,6 @@ public interface ApplicationComponent {
     void inject(DetailFragment movieDetailsFragment);
 
     void inject(SearchFragment searchFragment);
+
+    void inject(PersonDetailFragment personDetailFragment);
 }

--- a/app/src/main/java/com/halil/ozel/movieparadise/dagger/modules/HttpClientModule.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/dagger/modules/HttpClientModule.java
@@ -30,6 +30,7 @@ public class HttpClientModule {
     public static final String TOP_RATED = "movie/top_rated";
     public static final String UPCOMING = "movie/upcoming";
     public static final String MOVIE = "movie/";
+    public static final String PERSON = "person/";
     public static final String SEARCH_MOVIE = "search/movie";
 
     @Provides

--- a/app/src/main/java/com/halil/ozel/movieparadise/data/Api/TheMovieDbAPI.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/data/Api/TheMovieDbAPI.java
@@ -5,6 +5,8 @@ import com.halil.ozel.movieparadise.data.models.CreditsResponse;
 import com.halil.ozel.movieparadise.data.models.MovieDetails;
 import com.halil.ozel.movieparadise.data.models.MovieResponse;
 import com.halil.ozel.movieparadise.data.models.VideoResponse;
+import com.halil.ozel.movieparadise.data.models.Person;
+import com.halil.ozel.movieparadise.data.models.MovieCreditsResponse;
 
 import retrofit2.http.GET;
 import retrofit2.http.Path;
@@ -40,5 +42,11 @@ public interface TheMovieDbAPI {
 
     @GET(HttpClientModule.SEARCH_MOVIE)
     Observable<MovieResponse> getSearchMovies(@Query("query") String query,@Query("include_adult") Boolean include_adult, @Query("api_key") String apiKey);
+
+    @GET(HttpClientModule.PERSON + "{id}")
+    Observable<Person> getPerson(@Path("id") String personId, @Query("api_key") String apiKey);
+
+    @GET(HttpClientModule.PERSON + "{id}/movie_credits")
+    Observable<MovieCreditsResponse> getPersonMovieCredits(@Path("id") String personId, @Query("api_key") String apiKey);
 
 }

--- a/app/src/main/java/com/halil/ozel/movieparadise/data/models/MovieCreditsResponse.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/data/models/MovieCreditsResponse.java
@@ -1,0 +1,26 @@
+package com.halil.ozel.movieparadise.data.models;
+
+import java.util.List;
+
+public class MovieCreditsResponse {
+    private int id;
+    private List<Movie> cast;
+
+    public int getId() {
+        return id;
+    }
+
+    public MovieCreditsResponse setId(int id) {
+        this.id = id;
+        return this;
+    }
+
+    public List<Movie> getCast() {
+        return cast;
+    }
+
+    public MovieCreditsResponse setCast(List<Movie> cast) {
+        this.cast = cast;
+        return this;
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/DetailFragment.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/DetailFragment.java
@@ -53,6 +53,8 @@ import com.halil.ozel.movieparadise.ui.base.PaletteUtils;
 import com.halil.ozel.movieparadise.ui.movie.MovieCardView;
 import com.halil.ozel.movieparadise.ui.movie.MoviePresenter;
 import com.halil.ozel.movieparadise.ui.player.PlayerActivity;
+import com.halil.ozel.movieparadise.data.models.CastMember;
+import com.halil.ozel.movieparadise.ui.detail.PersonDetailActivity;
 
 import java.util.List;
 
@@ -310,6 +312,11 @@ public class DetailFragment extends DetailsFragment implements Palette.PaletteAs
             } else {
                 startActivity(intent);
             }
+        } else if (item instanceof CastMember) {
+            CastMember cast = (CastMember) item;
+            Intent intent = new Intent(getActivity(), PersonDetailActivity.class);
+            intent.putExtra(CastMember.class.getSimpleName(), cast);
+            startActivity(intent);
         }
     }
 }

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailActivity.java
@@ -1,0 +1,39 @@
+package com.halil.ozel.movieparadise.ui.detail;
+
+import android.os.Bundle;
+import androidx.core.content.ContextCompat;
+
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
+import com.halil.ozel.movieparadise.data.models.CastMember;
+import com.halil.ozel.movieparadise.ui.base.BaseTVActivity;
+import com.halil.ozel.movieparadise.ui.base.GlideBackgroundManager;
+
+public class PersonDetailActivity extends BaseTVActivity {
+
+    private GlideBackgroundManager glideBackgroundManager;
+    private CastMember castMember;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        castMember = getIntent().getParcelableExtra(CastMember.class.getSimpleName());
+        addFragment(PersonDetailFragment.newInstance(castMember));
+        glideBackgroundManager = new GlideBackgroundManager(this);
+        updateBackground();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        updateBackground();
+    }
+
+    private void updateBackground() {
+        if (castMember != null && castMember.getProfilePath() != null) {
+            glideBackgroundManager.loadImage(HttpClientModule.POSTER_URL + castMember.getProfilePath());
+        } else {
+            glideBackgroundManager.setBackground(ContextCompat.getDrawable(this, R.drawable.material_bg));
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailDescriptionPresenter.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailDescriptionPresenter.java
@@ -1,0 +1,28 @@
+package com.halil.ozel.movieparadise.ui.detail;
+
+import androidx.leanback.widget.Presenter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.data.models.Person;
+
+public class PersonDetailDescriptionPresenter extends Presenter {
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.detail_person, parent, false);
+        return new PersonDetailViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, Object item) {
+        Person person = (Person) item;
+        PersonDetailViewHolder holder = (PersonDetailViewHolder) viewHolder;
+        holder.bind(person);
+    }
+
+    @Override
+    public void onUnbindViewHolder(ViewHolder viewHolder) {}
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailFragment.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailFragment.java
@@ -1,0 +1,144 @@
+package com.halil.ozel.movieparadise.ui.detail;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.leanback.app.DetailsFragment;
+import androidx.leanback.widget.ArrayObjectAdapter;
+import androidx.leanback.widget.ClassPresenterSelector;
+import androidx.leanback.widget.DetailsOverviewLogoPresenter;
+import androidx.leanback.widget.DetailsOverviewRow;
+import androidx.leanback.widget.FullWidthDetailsOverviewSharedElementHelper;
+import androidx.leanback.widget.HeaderItem;
+import androidx.leanback.widget.ListRow;
+import androidx.leanback.widget.ListRowPresenter;
+import androidx.leanback.widget.OnItemViewClickedListener;
+import androidx.leanback.widget.Presenter;
+import androidx.leanback.widget.Row;
+import androidx.leanback.widget.RowPresenter;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.halil.ozel.movieparadise.App;
+import com.halil.ozel.movieparadise.Config;
+import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
+import com.halil.ozel.movieparadise.data.Api.TheMovieDbAPI;
+import com.halil.ozel.movieparadise.data.models.CastMember;
+import com.halil.ozel.movieparadise.data.models.Movie;
+import com.halil.ozel.movieparadise.data.models.MovieCreditsResponse;
+import com.halil.ozel.movieparadise.data.models.Person;
+import com.halil.ozel.movieparadise.ui.movie.MovieCardView;
+import com.halil.ozel.movieparadise.ui.movie.MoviePresenter;
+
+import javax.inject.Inject;
+
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
+
+public class PersonDetailFragment extends DetailsFragment implements OnItemViewClickedListener {
+
+    @Inject
+    TheMovieDbAPI theMovieDbAPI;
+
+    private CastMember castMember;
+    private Person person;
+    private ArrayObjectAdapter adapter;
+    private CustomDetailPresenter presenter;
+    private DetailsOverviewRow detailsRow;
+    private ArrayObjectAdapter movieAdapter = new ArrayObjectAdapter(new MoviePresenter());
+
+    public static PersonDetailFragment newInstance(CastMember cast) {
+        Bundle args = new Bundle();
+        args.putParcelable(CastMember.class.getSimpleName(), cast);
+        PersonDetailFragment fragment = new PersonDetailFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        App.instance().appComponent().inject(this);
+        castMember = getArguments().getParcelable(CastMember.class.getSimpleName());
+        setupAdapter();
+        setupDetailsRow();
+        setupMovieCredits();
+        setOnItemViewClickedListener(this);
+    }
+
+    private void setupAdapter() {
+        presenter = new CustomDetailPresenter(new PersonDetailDescriptionPresenter(), new DetailsOverviewLogoPresenter());
+        FullWidthDetailsOverviewSharedElementHelper helper = new FullWidthDetailsOverviewSharedElementHelper();
+        helper.setSharedElementEnterTransition(getActivity(), DetailFragment.TRANSITION_NAME);
+        presenter.setListener(helper);
+        presenter.setParticipatingEntranceTransition(false);
+
+        ClassPresenterSelector selector = new ClassPresenterSelector();
+        selector.addClassPresenter(DetailsOverviewRow.class, presenter);
+        selector.addClassPresenter(ListRow.class, new ListRowPresenter());
+        adapter = new ArrayObjectAdapter(selector);
+        setAdapter(adapter);
+    }
+
+    private void setupDetailsRow() {
+        detailsRow = new DetailsOverviewRow(new Person());
+        adapter.add(detailsRow);
+        loadImage(HttpClientModule.POSTER_URL + castMember.getProfilePath());
+        fetchPersonDetails();
+    }
+
+    private void setupMovieCredits() {
+        adapter.add(new ListRow(new HeaderItem(0, "Movies"), movieAdapter));
+    }
+
+    private void fetchPersonDetails() {
+        theMovieDbAPI.getPerson(String.valueOf(castMember.getId()), Config.API_KEY_URL)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::bindPersonDetails, e -> System.out.println(e.getMessage()));
+    }
+
+    private void fetchMovieCredits() {
+        theMovieDbAPI.getPersonMovieCredits(String.valueOf(castMember.getId()), Config.API_KEY_URL)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::bindMovieCredits, e -> System.out.println(e.getMessage()));
+    }
+
+    private void bindPersonDetails(Person p) {
+        this.person = p;
+        detailsRow.setItem(this.person);
+        fetchMovieCredits();
+    }
+
+    private void bindMovieCredits(MovieCreditsResponse response) {
+        movieAdapter.addAll(0, response.getCast());
+    }
+
+    private void loadImage(String url) {
+        Glide.with(getActivity())
+                .load(url)
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .into(detailsRow.getImageView(getActivity()));
+    }
+
+    @Override
+    public void onItemClicked(Presenter.ViewHolder itemViewHolder, Object item, RowPresenter.ViewHolder rowViewHolder, Row row) {
+        if (item instanceof Movie) {
+            Movie movie = (Movie) item;
+            Intent intent = new Intent(getActivity(), DetailActivity.class);
+            intent.putExtra(Movie.class.getSimpleName(), movie);
+
+            if (itemViewHolder.view instanceof MovieCardView) {
+                Bundle bundle = ActivityOptionsCompat.makeSceneTransitionAnimation(
+                        getActivity(),
+                        ((MovieCardView) itemViewHolder.view).getPosterIV(),
+                        DetailFragment.TRANSITION_NAME).toBundle();
+                getActivity().startActivity(intent, bundle);
+            } else {
+                startActivity(intent);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailViewHolder.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonDetailViewHolder.java
@@ -1,0 +1,39 @@
+package com.halil.ozel.movieparadise.ui.detail;
+
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.leanback.widget.Presenter;
+
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.data.models.Person;
+
+public class PersonDetailViewHolder extends Presenter.ViewHolder {
+
+    TextView nameTv;
+    TextView birthTv;
+    TextView bioTv;
+
+    public PersonDetailViewHolder(View view) {
+        super(view);
+        nameTv = view.findViewById(R.id.person_name);
+        birthTv = view.findViewById(R.id.person_birth);
+        bioTv = view.findViewById(R.id.person_bio);
+    }
+
+    public void bind(Person person) {
+        if (person != null) {
+            nameTv.setText(person.getName());
+            String born = "";
+            if (person.getBirthday() != null) {
+                born += person.getBirthday();
+            }
+            if (person.getPlaceOfBirth() != null) {
+                if (!born.isEmpty()) born += " - ";
+                born += person.getPlaceOfBirth();
+            }
+            birthTv.setText(born);
+            bioTv.setText(person.getBiography());
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonPresenter.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/detail/PersonPresenter.java
@@ -23,7 +23,9 @@ public class PersonPresenter extends Presenter {
         if (context == null) {
             context = new ContextThemeWrapper(parent.getContext(), R.style.PersonCardTheme);
         }
-        return new ViewHolder(new ImageCardView(context));
+        ImageCardView view = new ImageCardView(context);
+        view.setMainImageDimensions(200, 300);
+        return new ViewHolder(view);
     }
 
     @Override

--- a/app/src/main/res/layout/detail_person.xml
+++ b/app/src/main/res/layout/detail_person.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/person_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            tools:text="Person Name"/>
+
+        <TextView
+            android:id="@+id/person_birth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            tools:text="1980-01-01 - Place"/>
+
+        <TextView
+            android:id="@+id/bio_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Biography:"
+            android:textSize="16sp"
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/person_bio"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"/>
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary
- modernize cast card by enlarging its image view
- add API calls and model for fetching person details and movie credits
- add new Person detail activity/fragment with description presenter and layout
- open Person detail when a cast member is clicked
- register the new activity in the manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685796a0eefc832bacd0c57a3f4a1101