### PR TITLE
Fix search activity theme crash

### DIFF
--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/search/SearchActivity.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/search/SearchActivity.java
@@ -3,14 +3,14 @@ package com.halil.ozel.movieparadise.ui.search;
 import android.content.Intent;
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 
 import com.halil.ozel.movieparadise.R;
 
 /**
  * Hosts the {@link SearchFragment} using the support Fragment API.
  */
-public class SearchActivity extends AppCompatActivity {
+public class SearchActivity extends FragmentActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
## Summary
- use `FragmentActivity` for `SearchActivity` instead of `AppCompatActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6857bd56d7d0832b903cf9aceb4e042e