### PR TITLE
Add TV series browsing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,8 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.detail.DetailActivity" />
+        <activity android:name=".ui.tv.TvDetailActivity" />
+        <activity android:name=".ui.tv.TvMainActivity" />
         <activity android:name=".ui.detail.PersonDetailActivity" />
     </application>
 

--- a/app/src/main/java/com/halil/ozel/movieparadise/dagger/components/ApplicationComponent.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/dagger/components/ApplicationComponent.java
@@ -8,6 +8,8 @@ import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
 import com.halil.ozel.movieparadise.ui.detail.DetailFragment;
 import com.halil.ozel.movieparadise.ui.detail.PersonDetailFragment;
 import com.halil.ozel.movieparadise.ui.main.MainFragment;
+import com.halil.ozel.movieparadise.ui.tv.TvMainFragment;
+import com.halil.ozel.movieparadise.ui.tv.TvDetailFragment;
 import com.halil.ozel.movieparadise.ui.search.SearchFragment;
 
 import javax.inject.Singleton;
@@ -25,6 +27,10 @@ public interface ApplicationComponent {
     void inject(App app);
 
     void inject(MainFragment mainFragment);
+
+    void inject(TvMainFragment tvMainFragment);
+
+    void inject(TvDetailFragment tvDetailFragment);
 
     void inject(DetailFragment movieDetailsFragment);
 

--- a/app/src/main/java/com/halil/ozel/movieparadise/dagger/modules/HttpClientModule.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/dagger/modules/HttpClientModule.java
@@ -30,6 +30,10 @@ public class HttpClientModule {
     public static final String TOP_RATED = "movie/top_rated";
     public static final String UPCOMING = "movie/upcoming";
     public static final String MOVIE = "movie/";
+    public static final String TV_TOP_RATED = "tv/top_rated";
+    public static final String TV_POPULAR = "tv/popular";
+    public static final String TV_ON_THE_AIR = "tv/on_the_air";
+    public static final String TV_AIRING_TODAY = "tv/airing_today";
     public static final String PERSON = "person/";
     public static final String SEARCH_MOVIE = "search/movie";
 

--- a/app/src/main/java/com/halil/ozel/movieparadise/data/Api/TheMovieDbAPI.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/data/Api/TheMovieDbAPI.java
@@ -4,6 +4,7 @@ import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
 import com.halil.ozel.movieparadise.data.models.CreditsResponse;
 import com.halil.ozel.movieparadise.data.models.MovieDetails;
 import com.halil.ozel.movieparadise.data.models.MovieResponse;
+import com.halil.ozel.movieparadise.data.models.TvShowResponse;
 import com.halil.ozel.movieparadise.data.models.VideoResponse;
 import com.halil.ozel.movieparadise.data.models.Person;
 import com.halil.ozel.movieparadise.data.models.MovieCreditsResponse;
@@ -26,6 +27,18 @@ public interface TheMovieDbAPI {
 
     @GET(HttpClientModule.POPULAR)
     Observable<MovieResponse> getPopularMovies(@Query("api_key") String apiKey, @Query("page") int page);
+
+    @GET(HttpClientModule.TV_ON_THE_AIR)
+    Observable<TvShowResponse> getOnTheAir(@Query("api_key") String apiKey, @Query("page") int page);
+
+    @GET(HttpClientModule.TV_AIRING_TODAY)
+    Observable<TvShowResponse> getAiringToday(@Query("api_key") String apiKey, @Query("page") int page);
+
+    @GET(HttpClientModule.TV_POPULAR)
+    Observable<TvShowResponse> getPopularTv(@Query("api_key") String apiKey, @Query("page") int page);
+
+    @GET(HttpClientModule.TV_TOP_RATED)
+    Observable<TvShowResponse> getTopRatedTv(@Query("api_key") String apiKey, @Query("page") int page);
 
     @GET(HttpClientModule.MOVIE + "{id}/recommendations")
     Observable<MovieResponse> getRecommendations(@Path("id") String movieId, @Query("api_key") String apiKey);

--- a/app/src/main/java/com/halil/ozel/movieparadise/data/models/TvShow.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/data/models/TvShow.java
@@ -1,0 +1,195 @@
+package com.halil.ozel.movieparadise.data.models;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.squareup.moshi.Json;
+
+import java.util.List;
+
+/**
+ * Model class that mirrors the structure of a TV show returned by the
+ * TheMovieDb API.
+ */
+public class TvShow implements Parcelable {
+
+    private String id;
+
+    @Json(name = "poster_path")
+    private String posterPath;
+
+    private String overview;
+
+    @Json(name = "first_air_date")
+    private String firstAirDate;
+
+    @Json(name = "genre_ids")
+    private List<String> genreIds;
+
+    @Json(name = "original_name")
+    private String originalName;
+
+    @Json(name = "original_language")
+    private String originalLanguage;
+
+    /** Name of the TV show. */
+    @Json(name = "name")
+    private String name;
+
+    @Json(name = "backdrop_path")
+    private String backdropPath;
+
+    @Json(name = "vote_count")
+    private int voteCount;
+
+    @Json(name = "vote_average")
+    private float voteAverage;
+
+    public TvShow() {
+    }
+
+    protected TvShow(Parcel in) {
+        id = in.readString();
+        posterPath = in.readString();
+        overview = in.readString();
+        firstAirDate = in.readString();
+        genreIds = in.createStringArrayList();
+        originalName = in.readString();
+        originalLanguage = in.readString();
+        name = in.readString();
+        backdropPath = in.readString();
+        voteCount = in.readInt();
+        voteAverage = in.readFloat();
+    }
+
+    public static final Creator<TvShow> CREATOR = new Creator<TvShow>() {
+        @Override
+        public TvShow createFromParcel(Parcel in) {
+            return new TvShow(in);
+        }
+
+        @Override
+        public TvShow[] newArray(int size) {
+            return new TvShow[size];
+        }
+    };
+
+    public String getId() {
+        return id;
+    }
+
+    public TvShow setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getPosterPath() {
+        return posterPath;
+    }
+
+    public TvShow setPosterPath(String posterPath) {
+        this.posterPath = posterPath;
+        return this;
+    }
+
+    public String getOverview() {
+        return overview;
+    }
+
+    public TvShow setOverview(String overview) {
+        this.overview = overview;
+        return this;
+    }
+
+    public String getFirstAirDate() {
+        return firstAirDate;
+    }
+
+    public TvShow setFirstAirDate(String firstAirDate) {
+        this.firstAirDate = firstAirDate;
+        return this;
+    }
+
+    public List<String> getGenreIds() {
+        return genreIds;
+    }
+
+    public TvShow setGenreIds(List<String> genreIds) {
+        this.genreIds = genreIds;
+        return this;
+    }
+
+    public String getOriginalName() {
+        return originalName;
+    }
+
+    public TvShow setOriginalName(String originalName) {
+        this.originalName = originalName;
+        return this;
+    }
+
+    public String getOriginalLanguage() {
+        return originalLanguage;
+    }
+
+    public TvShow setOriginalLanguage(String originalLanguage) {
+        this.originalLanguage = originalLanguage;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public TvShow setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getBackdropPath() {
+        return backdropPath;
+    }
+
+    public TvShow setBackdropPath(String backdropPath) {
+        this.backdropPath = backdropPath;
+        return this;
+    }
+
+    public int getVoteCount() {
+        return voteCount;
+    }
+
+    public TvShow setVoteCount(int voteCount) {
+        this.voteCount = voteCount;
+        return this;
+    }
+
+    public float getVoteAverage() {
+        return voteAverage;
+    }
+
+    public TvShow setVoteAverage(float voteAverage) {
+        this.voteAverage = voteAverage;
+        return this;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(id);
+        dest.writeString(posterPath);
+        dest.writeString(overview);
+        dest.writeString(firstAirDate);
+        dest.writeStringList(genreIds);
+        dest.writeString(originalName);
+        dest.writeString(originalLanguage);
+        dest.writeString(name);
+        dest.writeString(backdropPath);
+        dest.writeInt(voteCount);
+        dest.writeFloat(voteAverage);
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/data/models/TvShowResponse.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/data/models/TvShowResponse.java
@@ -1,0 +1,94 @@
+package com.halil.ozel.movieparadise.data.models;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.squareup.moshi.Json;
+
+import java.util.List;
+
+/**
+ * Simple wrapper class used to parse paged TV show responses from the API.
+ */
+public class TvShowResponse implements Parcelable {
+
+    private int page;
+    private List<TvShow> results;
+
+    @Json(name = "total_pages")
+    private int totalPages;
+
+    @Json(name = "total_results")
+    private int totalResults;
+
+    public int getPage() {
+        return page;
+    }
+
+    public TvShowResponse setPage(int page) {
+        this.page = page;
+        return this;
+    }
+
+    public List<TvShow> getResults() {
+        return results;
+    }
+
+    public TvShowResponse setResults(List<TvShow> results) {
+        this.results = results;
+        return this;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public TvShowResponse setTotalPages(int totalPages) {
+        this.totalPages = totalPages;
+        return this;
+    }
+
+    public int getTotalResults() {
+        return totalResults;
+    }
+
+    public TvShowResponse setTotalResults(int totalResults) {
+        this.totalResults = totalResults;
+        return this;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(page);
+        dest.writeTypedList(results);
+        dest.writeInt(totalPages);
+        dest.writeInt(totalResults);
+    }
+
+    public TvShowResponse() {
+    }
+
+    protected TvShowResponse(Parcel in) {
+        this.page = in.readInt();
+        this.results = in.createTypedArrayList(TvShow.CREATOR);
+        this.totalPages = in.readInt();
+        this.totalResults = in.readInt();
+    }
+
+    public static final Creator<TvShowResponse> CREATOR = new Creator<TvShowResponse>() {
+        @Override
+        public TvShowResponse createFromParcel(Parcel source) {
+            return new TvShowResponse(source);
+        }
+
+        @Override
+        public TvShowResponse[] newArray(int size) {
+            return new TvShowResponse[size];
+        }
+    };
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailActivity.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailActivity.java
@@ -1,0 +1,43 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import android.os.Bundle;
+import androidx.core.content.ContextCompat;
+
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+import com.halil.ozel.movieparadise.ui.base.BaseTVActivity;
+import com.halil.ozel.movieparadise.ui.base.GlideBackgroundManager;
+
+/** Activity displaying details for a TV show. */
+public class TvDetailActivity extends BaseTVActivity {
+
+    private GlideBackgroundManager glideBackgroundManager;
+    private TvShow tvShow;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        tvShow = getIntent().getExtras().getParcelable(TvShow.class.getSimpleName());
+        TvDetailFragment detailsFragment = TvDetailFragment.newInstance(tvShow);
+        addFragment(detailsFragment);
+
+        glideBackgroundManager = new GlideBackgroundManager(this);
+        updateBackground();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        updateBackground();
+    }
+
+    private void updateBackground() {
+        if (tvShow != null && tvShow.getBackdropPath() != null) {
+            glideBackgroundManager.loadImage(HttpClientModule.BACKDROP_URL + tvShow.getBackdropPath());
+        } else {
+            glideBackgroundManager.setBackground(ContextCompat.getDrawable(this, R.drawable.material_bg));
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailDescriptionPresenter.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailDescriptionPresenter.java
@@ -1,0 +1,29 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import androidx.leanback.widget.Presenter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+
+/** Presenter responsible for binding TV show details. */
+public class TvDetailDescriptionPresenter extends Presenter {
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.activity_detail, parent, false);
+        return new TvDetailViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, Object item) {
+        TvShow tvShow = (TvShow) item;
+        TvDetailViewHolder holder = (TvDetailViewHolder) viewHolder;
+        holder.bind(tvShow);
+    }
+
+    @Override
+    public void onUnbindViewHolder(ViewHolder viewHolder) {}
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailFragment.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailFragment.java
@@ -1,0 +1,89 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.leanback.app.DetailsFragment;
+import androidx.leanback.widget.ArrayObjectAdapter;
+import androidx.leanback.widget.ClassPresenterSelector;
+import androidx.leanback.widget.DetailsOverviewLogoPresenter;
+import androidx.leanback.widget.DetailsOverviewRow;
+import androidx.leanback.widget.FullWidthDetailsOverviewSharedElementHelper;
+import androidx.leanback.widget.ListRow;
+import androidx.leanback.widget.ListRowPresenter;
+import androidx.leanback.widget.Presenter;
+import androidx.leanback.widget.Row;
+import androidx.leanback.widget.RowPresenter;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+import com.halil.ozel.movieparadise.ui.detail.CustomDetailPresenter;
+import com.halil.ozel.movieparadise.ui.tv.TvDetailDescriptionPresenter;
+
+/** Very lightweight detail fragment for TV shows. */
+public class TvDetailFragment extends DetailsFragment {
+
+    public static String TRANSITION_NAME = "poster_transition";
+
+    private TvShow tvShow;
+    private ArrayObjectAdapter arrayObjectAdapter;
+    private CustomDetailPresenter customDetailPresenter;
+    private DetailsOverviewRow detailsOverviewRow;
+
+    public static TvDetailFragment newInstance(TvShow show) {
+        Bundle args = new Bundle();
+        args.putParcelable(TvShow.class.getSimpleName(), show);
+        TvDetailFragment fragment = new TvDetailFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() == null || !getArguments().containsKey(TvShow.class.getSimpleName())) {
+            throw new RuntimeException("A tv show is necessary for TvDetailFragment");
+        }
+        tvShow = getArguments().getParcelable(TvShow.class.getSimpleName());
+        setUpAdapter();
+        setUpDetailsOverviewRow();
+    }
+
+    private void setUpAdapter() {
+        customDetailPresenter = new CustomDetailPresenter(new TvDetailDescriptionPresenter(), new DetailsOverviewLogoPresenter());
+        FullWidthDetailsOverviewSharedElementHelper helper = new FullWidthDetailsOverviewSharedElementHelper();
+        helper.setSharedElementEnterTransition(getActivity(), TRANSITION_NAME);
+        customDetailPresenter.setListener(helper);
+        customDetailPresenter.setParticipatingEntranceTransition(false);
+
+        ClassPresenterSelector selector = new ClassPresenterSelector();
+        selector.addClassPresenter(DetailsOverviewRow.class, customDetailPresenter);
+        selector.addClassPresenter(ListRow.class, new ListRowPresenter());
+        arrayObjectAdapter = new ArrayObjectAdapter(selector);
+        setAdapter(arrayObjectAdapter);
+    }
+
+    private void setUpDetailsOverviewRow() {
+        detailsOverviewRow = new DetailsOverviewRow(tvShow);
+        arrayObjectAdapter.add(detailsOverviewRow);
+        loadImage(HttpClientModule.POSTER_URL + tvShow.getPosterPath());
+    }
+
+    private void loadImage(String url) {
+        if (url == null || url.isEmpty()) {
+            return;
+        }
+        Glide.with(this)
+                .load(url)
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .placeholder(R.drawable.popcorn)
+                .into(new ImageView(getActivity()));
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailViewHolder.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvDetailViewHolder.java
@@ -1,0 +1,47 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.leanback.widget.Presenter;
+
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+
+import java.util.Locale;
+
+/** Simple view holder used by {@link TvDetailDescriptionPresenter}. */
+public class TvDetailViewHolder extends Presenter.ViewHolder {
+
+    TextView titleTv;
+    TextView yearTv;
+    TextView overviewTv;
+    TextView ratingTv;
+    TextView taglineTv;
+    LinearLayout genresLayout;
+
+    private final View itemView;
+
+    public TvDetailViewHolder(View view) {
+        super(view);
+        itemView = view;
+        titleTv = itemView.findViewById(R.id.movie_title);
+        yearTv = itemView.findViewById(R.id.movie_year);
+        overviewTv = itemView.findViewById(R.id.overview);
+        ratingTv = itemView.findViewById(R.id.rating);
+        taglineTv = itemView.findViewById(R.id.tagline);
+        genresLayout = itemView.findViewById(R.id.genres);
+    }
+
+    public void bind(TvShow show) {
+        titleTv.setText(show.getName());
+        if (show.getFirstAirDate() != null && show.getFirstAirDate().length() >= 4) {
+            yearTv.setText(String.format(Locale.getDefault(), "(%s)", show.getFirstAirDate().substring(0, 4)));
+        }
+        overviewTv.setText(show.getOverview());
+        ratingTv.setText(String.format(Locale.getDefault(), "%.1f/10", show.getVoteAverage()));
+        taglineTv.setVisibility(View.GONE);
+        genresLayout.removeAllViews();
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvMainActivity.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvMainActivity.java
@@ -1,0 +1,13 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import android.os.Bundle;
+import com.halil.ozel.movieparadise.ui.base.BaseTVActivity;
+
+/** Activity that hosts {@link TvMainFragment}. */
+public class TvMainActivity extends BaseTVActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addFragment(TvMainFragment.newInstance());
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvMainFragment.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvMainFragment.java
@@ -1,0 +1,207 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.SparseArray;
+
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.content.ContextCompat;
+import androidx.leanback.app.BrowseFragment;
+import androidx.leanback.widget.ArrayObjectAdapter;
+import androidx.leanback.widget.HeaderItem;
+import androidx.leanback.widget.ListRow;
+import androidx.leanback.widget.ListRowPresenter;
+import androidx.leanback.widget.OnItemViewClickedListener;
+import androidx.leanback.widget.OnItemViewSelectedListener;
+import androidx.leanback.widget.Presenter;
+import androidx.leanback.widget.Row;
+import androidx.leanback.widget.RowPresenter;
+
+import com.halil.ozel.movieparadise.App;
+import com.halil.ozel.movieparadise.Config;
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
+import com.halil.ozel.movieparadise.data.Api.TheMovieDbAPI;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+import com.halil.ozel.movieparadise.data.models.TvShowResponse;
+import com.halil.ozel.movieparadise.ui.base.GlideBackgroundManager;
+import com.halil.ozel.movieparadise.ui.tv.TvDetailFragment;
+import com.halil.ozel.movieparadise.ui.tv.TvDetailActivity;
+
+import javax.inject.Inject;
+
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
+
+/** Fragment that lists TV series categories. */
+public class TvMainFragment extends BrowseFragment implements OnItemViewSelectedListener, OnItemViewClickedListener {
+
+    @Inject
+    TheMovieDbAPI theMovieDbAPI;
+
+    GlideBackgroundManager glideBackgroundManager;
+
+    private TvShow selectedShow;
+
+    private static final int ON_THE_AIR = 0;
+    private static final int AIRING_TODAY = 1;
+    private static final int POPULAR = 2;
+    private static final int TOP_RATED = 3;
+
+    SparseArray<MovieRow> tvRowSparseArray;
+
+    public static TvMainFragment newInstance() {
+        Bundle args = new Bundle();
+        TvMainFragment fragment = new TvMainFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        App.instance().appComponent().inject(this);
+
+        glideBackgroundManager = new GlideBackgroundManager(getActivity());
+
+        setBrandColor(ContextCompat.getColor(getActivity(), R.color.primary_transparent));
+        setHeadersState(HEADERS_ENABLED);
+        setHeadersTransitionOnBackEnabled(true);
+
+        createDataRows();
+        createRows();
+        prepareEntranceTransition();
+        fetchOnTheAir();
+        fetchAiringToday();
+        fetchPopular();
+        fetchTopRated();
+    }
+
+    private void createDataRows() {
+        tvRowSparseArray = new SparseArray<>();
+
+        TvShowPresenter presenter = new TvShowPresenter();
+
+        tvRowSparseArray.put(ON_THE_AIR, new MovieRow()
+                .setId(ON_THE_AIR)
+                .setAdapter(new ArrayObjectAdapter(presenter))
+                .setTitle("On The Air")
+                .setPage(1)
+        );
+
+        tvRowSparseArray.put(AIRING_TODAY, new MovieRow()
+                .setId(AIRING_TODAY)
+                .setAdapter(new ArrayObjectAdapter(presenter))
+                .setTitle("Airing Today")
+                .setPage(1)
+        );
+
+        tvRowSparseArray.put(POPULAR, new MovieRow()
+                .setId(POPULAR)
+                .setAdapter(new ArrayObjectAdapter(presenter))
+                .setTitle("Popular TV")
+                .setPage(1)
+        );
+
+        tvRowSparseArray.put(TOP_RATED, new MovieRow()
+                .setId(TOP_RATED)
+                .setAdapter(new ArrayObjectAdapter(presenter))
+                .setTitle("Top Rated TV")
+                .setPage(1)
+        );
+    }
+
+    private void createRows() {
+        ArrayObjectAdapter rowsAdapter = new ArrayObjectAdapter(new ListRowPresenter());
+        for (int i = 0; i < tvRowSparseArray.size(); i++) {
+            MovieRow row = tvRowSparseArray.get(i);
+            HeaderItem headerItem = new HeaderItem(row.getId(), row.getTitle());
+            ListRow listRow = new ListRow(headerItem, row.getAdapter());
+            rowsAdapter.add(listRow);
+        }
+        setAdapter(rowsAdapter);
+        setOnItemViewSelectedListener(this);
+        setOnItemViewClickedListener(this);
+    }
+
+    private void fetchOnTheAir() {
+        theMovieDbAPI.getOnTheAir(Config.API_KEY_URL, tvRowSparseArray.get(ON_THE_AIR).getPage())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(r -> { bindTvResponse(r, ON_THE_AIR); startEntranceTransition(); }, e -> System.out.println(e.getMessage()));
+    }
+
+    private void fetchAiringToday() {
+        theMovieDbAPI.getAiringToday(Config.API_KEY_URL, tvRowSparseArray.get(AIRING_TODAY).getPage())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(r -> { bindTvResponse(r, AIRING_TODAY); startEntranceTransition(); }, e -> System.out.println(e.getMessage()));
+    }
+
+    private void fetchPopular() {
+        theMovieDbAPI.getPopularTv(Config.API_KEY_URL, tvRowSparseArray.get(POPULAR).getPage())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(r -> { bindTvResponse(r, POPULAR); startEntranceTransition(); }, e -> System.out.println(e.getMessage()));
+    }
+
+    private void fetchTopRated() {
+        theMovieDbAPI.getTopRatedTv(Config.API_KEY_URL, tvRowSparseArray.get(TOP_RATED).getPage())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(r -> { bindTvResponse(r, TOP_RATED); startEntranceTransition(); }, e -> System.out.println(e.getMessage()));
+    }
+
+    private void bindTvResponse(TvShowResponse response, int id) {
+        MovieRow row = tvRowSparseArray.get(id);
+        row.setPage(row.getPage() + 1);
+        for (TvShow tvShow : response.getResults()) {
+            if (tvShow.getPosterPath() != null) {
+                row.getAdapter().add(tvShow);
+            }
+        }
+    }
+
+    private void updateBackground(TvShow show) {
+        if (show != null) {
+            if (show.getBackdropPath() != null) {
+                glideBackgroundManager.loadImage(HttpClientModule.BACKDROP_URL + show.getBackdropPath());
+            } else {
+                glideBackgroundManager.setBackground(ContextCompat.getDrawable(getActivity(), R.drawable.material_bg));
+            }
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateBackground(selectedShow);
+    }
+
+    @Override
+    public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item, RowPresenter.ViewHolder rowViewHolder, Row row) {
+        if (item instanceof TvShow) {
+            selectedShow = (TvShow) item;
+            updateBackground(selectedShow);
+        }
+    }
+
+    @Override
+    public void onItemClicked(Presenter.ViewHolder itemViewHolder, Object item, RowPresenter.ViewHolder rowViewHolder, Row row) {
+        if (item instanceof TvShow) {
+            TvShow tvShow = (TvShow) item;
+            Intent intent = new Intent(getActivity(), TvDetailActivity.class);
+            intent.putExtra(TvShow.class.getSimpleName(), tvShow);
+
+            if (itemViewHolder.view instanceof TvShowCardView) {
+                Bundle bundle = ActivityOptionsCompat.makeSceneTransitionAnimation(
+                        getActivity(),
+                        ((TvShowCardView) itemViewHolder.view).getPosterIV(),
+                        TvDetailFragment.TRANSITION_NAME).toBundle();
+                getActivity().startActivity(intent, bundle);
+            } else {
+                startActivity(intent);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvShowCardView.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvShowCardView.java
@@ -1,0 +1,51 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import android.content.Context;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.halil.ozel.movieparadise.R;
+import com.halil.ozel.movieparadise.dagger.modules.HttpClientModule;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+import com.halil.ozel.movieparadise.ui.base.BindableCardView;
+
+/** Card view used for TV show items. */
+public class TvShowCardView extends BindableCardView<TvShow> {
+
+    ImageView mPosterIV;
+    TextView title_tv;
+
+    public TvShowCardView(Context context) {
+        super(context);
+        mPosterIV = findViewById(R.id.poster_iv);
+        title_tv = findViewById(R.id.title_tv);
+    }
+
+    @Override
+    protected void bind(TvShow show) {
+        String posterPath = show.getPosterPath();
+        if (posterPath == null || posterPath.isEmpty()) {
+            Glide.with(getContext())
+                    .load(R.drawable.popcorn)
+                    .into(mPosterIV);
+        } else {
+            Glide.with(getContext())
+                    .load(HttpClientModule.POSTER_URL + posterPath)
+                    .diskCacheStrategy(DiskCacheStrategy.ALL)
+                    .placeholder(R.drawable.popcorn)
+                    .into(mPosterIV);
+        }
+        title_tv.setText(show.getName());
+    }
+
+    public ImageView getPosterIV() {
+        return mPosterIV;
+    }
+
+    @Override
+    protected int getLayoutResource() {
+        return R.layout.card_movie;
+    }
+}

--- a/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvShowPresenter.java
+++ b/app/src/main/java/com/halil/ozel/movieparadise/ui/tv/TvShowPresenter.java
@@ -1,0 +1,24 @@
+package com.halil.ozel.movieparadise.ui.tv;
+
+import androidx.leanback.widget.Presenter;
+import android.view.ViewGroup;
+import com.halil.ozel.movieparadise.data.models.TvShow;
+
+/** Presenter used to render TV show cards. */
+public class TvShowPresenter extends Presenter {
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent) {
+        return new ViewHolder(new TvShowCardView(parent.getContext()));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, Object item) {
+        ((TvShowCardView) viewHolder.view).bind((TvShow) item);
+    }
+
+    @Override
+    public void onUnbindViewHolder(ViewHolder viewHolder) {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Summary
- expand HTTP module with TV endpoints
- expose TV endpoints on the API interface
- add `TvShow` model and paged `TvShowResponse`
- implement TV UI with new fragments and presenters
- include simple TV detail screen
- register new activities in the manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857c4bf6ac4832bb355abc05747241d